### PR TITLE
fix(STK-267): strategies not working properly with new token picker

### DIFF
--- a/packages/app/components/stackbox/FrequencyOptionsCard.tsx
+++ b/packages/app/components/stackbox/FrequencyOptionsCard.tsx
@@ -82,7 +82,7 @@ export const FrequencyOptionsCard = ({
   );
   const [customFrequency, setCustomFrequency] = useState("");
 
-  const { selectedStrategy } = useStrategyContext();
+  const { deselectStrategy, selectedStrategy } = useStrategyContext();
 
   const handleCustomFrequencyChange = (
     event: ChangeEvent<HTMLInputElement>
@@ -103,6 +103,8 @@ export const FrequencyOptionsCard = ({
       setDefaultFrequency("");
       setCustomFrequency(newValue);
     }
+
+    if (selectedStrategy) deselectStrategy();
   };
 
   useEffect(() => {
@@ -161,6 +163,7 @@ export const FrequencyOptionsCard = ({
                 onChange={(event) => {
                   setDefaultFrequency(event.target.value as FREQUENCY_OPTIONS);
                   if (!!customFrequency) setCustomFrequency("");
+                  if (selectedStrategy) deselectStrategy();
                 }}
                 value={freqOption}
               >

--- a/packages/app/components/stackbox/FrequencyOptionsCard.tsx
+++ b/packages/app/components/stackbox/FrequencyOptionsCard.tsx
@@ -10,24 +10,6 @@ import { FREQUENCY_OPTIONS } from "@/models";
 import { BodyText, RadioButton, TextInput } from "@/ui";
 import { cx } from "class-variance-authority";
 
-const parseDaysToFrequencyAmount = (
-  days: number,
-  frequency: FREQUENCY_OPTIONS
-) => {
-  switch (frequency) {
-    case FREQUENCY_OPTIONS.hour:
-      return days * 24;
-    case FREQUENCY_OPTIONS.day:
-      return days;
-    case FREQUENCY_OPTIONS.week:
-      return daysToWeeks(days);
-    case FREQUENCY_OPTIONS.month:
-      return days / 30;
-    default:
-      throw new Error("Invalid frequency option");
-  }
-};
-
 interface FrequencyOptionsCardProps {
   frequency: FREQUENCY_OPTIONS;
   setEndDate: (date: Date) => void;
@@ -71,6 +53,26 @@ const getCroppedFrequency = (frequency: FREQUENCY_OPTIONS) => {
   const isMonthFrequency = frequency === FREQUENCY_OPTIONS.month;
 
   return isMonthFrequency ? frequency.substring(0, 2) : frequency.charAt(0);
+};
+
+const parseDaysToFrequencyAmount = (
+  days: number,
+  frequency: FREQUENCY_OPTIONS
+) => {
+  switch (frequency) {
+    case FREQUENCY_OPTIONS.hour:
+      return days * 24;
+    case FREQUENCY_OPTIONS.day:
+      return days;
+    case FREQUENCY_OPTIONS.week:
+      return daysToWeeks(days);
+    case FREQUENCY_OPTIONS.month:
+      return days / 30;
+    default: {
+      console.error("Invalid frequency option", frequency);
+      return maxCustomFrequencies[frequency];
+    }
+  }
 };
 
 export const FrequencyOptionsCard = ({

--- a/packages/app/components/strategies/constants.tsx
+++ b/packages/app/components/strategies/constants.tsx
@@ -93,7 +93,7 @@ export const STRATEGY_CATEGORIES: { [chainId: number]: ChainStrategies } = {
         {
           id: 3,
           buyToken: gnosisTokens.WETH,
-          daysAmount: 10,
+          daysAmount: 4,
           frequency: FREQUENCY_OPTIONS.hour,
           sellAmountPerTimeframe: 5,
           sellToken: gnosisTokens.USDC,
@@ -136,7 +136,7 @@ export const STRATEGY_CATEGORIES: { [chainId: number]: ChainStrategies } = {
         {
           id: 3,
           buyToken: arbitrumTokens.WETH,
-          daysAmount: 10,
+          daysAmount: 4,
           frequency: FREQUENCY_OPTIONS.hour,
           sellAmountPerTimeframe: 5,
           sellToken: arbitrumTokens.USDC,
@@ -179,7 +179,7 @@ export const STRATEGY_CATEGORIES: { [chainId: number]: ChainStrategies } = {
         {
           id: 3,
           buyToken: baseTokens.CBBTC,
-          daysAmount: 10,
+          daysAmount: 4,
           frequency: FREQUENCY_OPTIONS.hour,
           sellAmountPerTimeframe: 5,
           sellToken: baseTokens.USDC,


### PR DESCRIPTION
## Fixes: [STK-267](https://linear.app/swaprhq/issue/STK-267/strategies-not-working-properly-with-new-token-picker)

## Description
* Updates our existing strategies to fit the new frequency picker constrains
* Updates our frequency card picker so it can handle the strategy selection

## Visual Evidence
https://www.loom.com/share/5210e383aeb54a9891eada4b09d584fb?sid=7d350ff1-231d-41fa-8925-eb964ea87359
